### PR TITLE
fix: correct server path in CLI launcher

### DIFF
--- a/bin/mcp-think-tank-cli.js
+++ b/bin/mcp-think-tank-cli.js
@@ -9,7 +9,7 @@
 console.log = (...args) => console.error(...args);
 
 // Use dynamic import which works in both ESM and CommonJS
-import('../dist/src/server.js').catch(e => {
+import('../dist/server.js').catch(e => {
   console.error(`Failed to start MCP Think Tank server:`, e);
   process.exit(1);
 }); 


### PR DESCRIPTION
## Summary
- adjust CLI server import path

## Testing
- `npm test` *(fails: vitest not found)*